### PR TITLE
修正异常模板配置逻辑

### DIFF
--- a/application/common/behavior/Common.php
+++ b/application/common/behavior/Common.php
@@ -30,11 +30,8 @@ class Common
         {
             // 如果是调试模式将version置为当前的时间戳可避免缓存
             Config::set('site.version', time());
-        }
-        else
-        {
-            // 如果是开发模式修改异常页的模板
-            Config::set('exception_tmpl', APP_PATH . 'common' . DS . 'view' . DS . 'tpl' . DS . 'think_exception.tpl');
+            // 如果是开发模式那么将异常模板修改成官方的
+            Config::set('exception_tmpl',THINK_PATH . 'tpl' . DS . 'think_exception.tpl');
         }
         // 如果是trace模式且Ajax的情况下关闭trace
         if (Config::get('app_trace') && $request->isAjax())

--- a/application/config.php
+++ b/application/config.php
@@ -144,7 +144,7 @@ return [
     // | 异常及错误设置
     // +----------------------------------------------------------------------
     // 异常页面的模板文件
-    'exception_tmpl'         => THINK_PATH . 'tpl' . DS . 'think_exception.tpl',
+    'exception_tmpl'         => APP_PATH . 'common' . DS . 'view' . DS . 'tpl' . DS . 'think_exception.tpl',
     // 错误显示信息,非调试模式有效
     'error_message'          => '你所浏览的页面暂时无法访问',
     // 显示错误信息


### PR DESCRIPTION
在module无法找到以及debug处于关闭下，会显示TP默认的错误页。那么修改异常模板逻辑，在config中默认配置友好的错误页面。在behavior下，判断是否debug开启，若有开启，才改成官方模板