### PR TITLE
修复因Ajax POST请求静态资源服务器返回 405 Not Allowed 的错误

### DIFF
--- a/public/assets/js/backend/addon.js
+++ b/public/assets/js/backend/addon.js
@@ -760,7 +760,7 @@ define(['jquery', 'bootstrap', 'backend', 'table', 'form', 'template'], function
                 //刷新左侧边栏
                 Fast.api.refreshmenu();
                 //刷新插件JS缓存
-                Fast.api.ajax({url: require.toUrl('addons.js'), loading: false}, function () {
+                Fast.api.ajax({type: 'GET', url: require.toUrl('addons.js'), loading: false}, function () {
                     return false;
                 }, function () {
                     return false;


### PR DESCRIPTION
Fast.api.ajax()默认的 POST 请求 'addons.js' ，会引发一些服务器 405 Not Allowed 的错误