### PR TITLE
修复(Fix): 修复自定义控制台URL无法在新标签页中打开的问题

### DIFF
--- a/extend/fast/Tree.php
+++ b/extend/fast/Tree.php
@@ -323,7 +323,7 @@ class Tree
                 $value = array(
                     '@childlist' => $childlist,
                     '@url'       => $childdata || !isset($value['@url']) ? "javascript:;" : $value['@url'],
-                    '@addtabs'   => $childdata || !isset($value['@url']) ? "" : (stripos($value['@url'], "?") !== false ? "&" : "?") . "ref=addtabs",
+                    '@addtabs'   => $childdata || isset($value['@url']) ? "" : (stripos($value['@url'], "?") !== false ? "&" : "?") . "ref=addtabs",
                     '@caret'     => ($childdata && (!isset($value['@badge']) || !$value['@badge']) ? '<i class="fa fa-angle-left"></i>' : ''),
                     '@badge'     => $value['@badge'] ?? '',
                     '@class'     => ($selected ? ' active' : '') . ($disabled ? ' disabled' : '') . ($childdata ? ' treeview' . (config('fastadmin.show_submenu') ? ' treeview-open' : '') : ''),


### PR DESCRIPTION
### PR 类型 (Type of change)

- [x] Bug 修复 (Bug fix)
- [ ] 新功能 (New feature)
- [ ] 代码样式更新 (Code style update)
- [ ] 功能重构 (Refactoring)
- [ ] 其他

### 问题背景 (Problem/Motivation)

![截图 2025-06-18 22-42-23](https://github.com/user-attachments/assets/e7ac7e2d-1ee3-42e6-99fd-3c9ec46426a1)
在 FastAdmin 中，所有通过 `Tree` 类生成的菜单项，只要包含 URL (`@url`)，系统就会自动为其追加 `ref=addtabs` 参数。

这个设计虽然保证了大部分内部页面能在框架的 Tab 页中打开，但也带来了一个问题：当我们需要将某个菜单项（例如“控制台”或任何自定义菜单）指向一个外部网站，或者一个需要脱离框架独立显示的内部页面时，`ref=addtabs` 参数会强制它在框架内打开，导致页面无法正常显示或不符合预期。

### 解决方案 (Proposed Solution)

本次修改位于 `extend/fast/Tree.php` 文件中，调整了 `getTreeArray` 方法内构建菜单属性的逻辑。

核心改动是移除了判断条件中的 `!` (NOT) 运算符。

**代码变更:**

```php
// 文件: extend/fast/Tree.php

// 修改前
'@addtabs'   => $childdata || !isset($value['@url']) ? "" : (stripos($value['@url'], "?") !== false ? "&" : "?") . "ref=addtabs",

// 修改后
'@addtabs'   => $childdata || isset($value['@url']) ? "" : (stripos($value['@url'], "?") !== false ? "&" : "?") . "ref=addtabs",
```

**逻辑解释:**

*   **修改前:** `'@addtabs'` 属性为空的条件是 `($childdata || !isset($value['@url']))`。这意味着，只有当一个菜单项是父级菜单（有子菜单）或**没有设置URL**时，`ref=addtabs` 才不会被添加。反之，只要是末级菜单且**设置了URL**，就会被添加。
*   **修改后:** `'@addtabs'` 属性为空的条件变为 `($childdata || isset($value['@url']))`。这意味着，只要一个菜单项是父级菜单或**设置了URL**，`ref=addtabs` 就不会被添加。

**最终效果是，该 PHP 后端逻辑将不再为任何含有 `@url` 的菜单项自动附加 `ref=addtabs` 参数。** 这将控制权交还给前端或URL本身，允许我们自由定义哪些链接需要在框架内打开，哪些需要在新标签页打开。

### 如何测试 (How to Test)

1.  登录后台，进入 [权限管理] -> [菜单规则]。
2.  添加一个新的菜单规则，或编辑一个现有的（例如“控制台”）。
3.  将其URL设置为一个外部地址，例如 `https://www.google.com`。
4.  保存后刷新后台页面。
5.  点击你修改的那个菜单项。
6.  **预期结果：** 浏览器会打开一个新的标签页，并跳转到 `https://www.google.com`。
7.  **同时，请测试一个常规的内部链接**，例如点击 [权限管理] -> [管理员管理]。确认其行为是否仍符合预期（通常，FastAdmin 的前端 JS 逻辑仍然会处理内部链接，使其在 Tab 页中打开）。
![截图 2025-06-18 22-53-05](https://github.com/user-attachments/assets/0a36707a-69e8-4823-94b2-787eeb58fe05)